### PR TITLE
Added Rubyconf Brazil 2014

### DIFF
--- a/data/current.json
+++ b/data/current.json
@@ -169,6 +169,12 @@
 		"cfp_phrase": "CFP closes",
 		"cfp_date": "May 9, 2014"
 	}, {
+		"name" : "RubyConf Brazil 2014",
+		"location" : "São Paulo, Brazil",
+		"dates" : "August 28-29, 2014",
+		"url" : "http://www.rubyconf.com.br/",
+		"twitter" : "rubyconfbr"
+	}, {
 		"name" : "WindyCityRails",
 		"location" : "Chicago, IL",
 		"dates" : "September 4-5, 2014",


### PR DESCRIPTION
The dates are set as announced by @akitaonrails on his blog, http://www.akitaonrails.com/2013/10/07/rubyconf-brasil-2014-dates-are-set, but the main side still shows the info for the 2013 edition. I'll update it again when the CFP opens.
