### PR TITLE
Updates end of CFP date of Tropical Ruby 2015 (again)

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -46,7 +46,7 @@
   url: http://tropicalrb.com/
   twitter: tropicalrb
   cfp_phrase: CFP closes
-  cfp_date: "January 10, 2015"
+  cfp_date: "December 7, 2014"
 
 - name: Bath Ruby Conference
   location: Bath, UK

--- a/source/news/posts/2014-10-27-tropical-ruby-opens-cfp.html.md
+++ b/source/news/posts/2014-10-27-tropical-ruby-opens-cfp.html.md
@@ -2,6 +2,6 @@
 title: Tropical Ruby Opens CFP
 ---
 
-The Tropical Ruby [call for proprosals][cfp] is open now through January 10th.
+The Tropical Ruby [call for proprosals][cfp] is open now through December 7th.
 
 [cfp]: http://cfp.tropicalrb.com/events/tropicalrb-2015


### PR DESCRIPTION
We decided to change the date of CFP so speakers have more time to prepare their travel.
