### PR TITLE
Add 2015 Burlington Ruby Conference to current

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -96,6 +96,12 @@
   dates: "April 21-23, 2015"
   url: http://www.railsconf.com/
   twitter: railsconf
+  
+- name: Burlington Ruby Conference
+  location: Burlington, VT
+  dates: "July 31st, August 1st, and August 2nd, 2015"
+  url: http://burlingtonrubyconference.com/
+  twitter: btvrubyconf
 
 - name: WindyCityRails
   location: Chicago, IL


### PR DESCRIPTION
The conference is happening, basically the same weekend as this past year. This adds it to the list of current conferences.
