### PR TITLE
Remove registration state for Garden City Rubyconf

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -3,7 +3,6 @@
   dates: "January 10, 2015"
   url: http://www.gardencityruby.org/
   twitter: gardencityrb
-  reg_phrase: Registration is open
 
 - name: Ruby devroom at FOSDEM
   location: Brussels, Belgium


### PR DESCRIPTION
* This event is happening today, and the registration is closed.