### PR TITLE
Added RubyConfLT

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -28,6 +28,12 @@
   dates: "March 13-15, 2015"
   url: http://wrocloverb.com/
   twitter: wrocloverb
+  
+- name: Lithuanian Ruby Conference
+  location: Vilnius, Lithuania
+  dates: "March 21, 2015"
+  url: http://rubyconf.lt/
+  twitter: rubyconflt
 
 - name: Ancient City Ruby
   location: St. Augustine, FL


### PR DESCRIPTION
Lithuanian Ruby Conference on 21 of March, 2015 in Vilnius.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ruby-conferences/ruby-conferences-site/66)
<!-- Reviewable:end -->
