### PR TITLE
Add RubyWorld Conference 2015

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -4,18 +4,18 @@
   url: https://ruby.onales.com/
   twitter: rbonales
 
-- name: MountainWest RubyConf
-  location: Salt Lake City, UT
-  dates: "March 9-10, 2015"
-  url: http://mtnwestrubyconf.org
-  twitter: mwrc
-  reg_phrase: Registration is open
-
 - name: Tropical Ruby
   location: Porto de Galinhas, Brazil
   dates: "March 5-8, 2015"
   url: http://tropicalrb.com/
   twitter: tropicalrb
+  reg_phrase: Registration is open
+
+- name: MountainWest RubyConf
+  location: Salt Lake City, UT
+  dates: "March 9-10, 2015"
+  url: http://mtnwestrubyconf.org
+  twitter: mwrc
   reg_phrase: Registration is open
 
 - name: Bath Ruby Conference
@@ -139,14 +139,14 @@
   cfp_phrase: CFP closes
   cfp_date: "March 31, 2015"
 
-- name: RubyConf
-  location: San Antonio, TX
-  dates: "November 15-17, 2015"
-  url: http://rubyconf.org/
-  twitter: rubyconf
-
 - name: Rocky Mountain Ruby Conference
   location: Boulder, CO
   dates: "September 23-25, 2015"
   url: http://www.rockymtnruby.com/
   twitter: rockymtnruby
+
+- name: RubyConf
+  location: San Antonio, TX
+  dates: "November 15-17, 2015"
+  url: http://rubyconf.org/
+  twitter: rubyconf

--- a/data/current.yml
+++ b/data/current.yml
@@ -145,6 +145,12 @@
   url: http://www.rockymtnruby.com/
   twitter: rockymtnruby
 
+- name: RubyWorld Conference
+  location: Matsue, Japan
+  dates: "November 11-12, 2015"
+  url: http://www.rubyworld-conf.org/
+  twitter: rubyworldconf
+
 - name: RubyConf
   location: San Antonio, TX
   dates: "November 15-17, 2015"


### PR DESCRIPTION
RubyWorld Conference is an annual international Ruby conference in Matz's hometown, Matz-e, Japan.

The dates for RWC2015 had been officially announced here http://www.rubyworld-conf.org/ja/news/2015/02/rwc2015/
(I'm sorry I couldn't find the English announcement)

Also, sorted the conferences by their dates.