### PR TITLE
Bump eventmachine for Ruby 2.2 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     em-websocket (0.5.0)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.5.3)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.9.3)


### PR DESCRIPTION
Trying to `bundle` on Ruby 2.2 blew up on eventmachine install; bumping it to the current version solved the problem.