### PR TITLE
Add RubyConf Brazil 2015

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -81,7 +81,7 @@
   twitter: eurucamp
   cfp_phrase: CFP closes
   cfp_date: "May 1, 2015"
-  
+
 - name: DeccanRubyConf
   location: Pune, India
   dates: "August 8, 2015"
@@ -138,6 +138,14 @@
   reg_phrase: Registration is open
   cfp_phrase: CFP closes
   cfp_date: "March 31, 2015"
+
+- name: RubyConf Brazil
+  location: São Paulo, Brazil
+  dates: "September 18-19, 2015"
+  url: http://rubyconfbrcfp.com.br
+  reg_phrase: CFP is open
+  cfp_phrase: CFP closes
+  cfp_date: "May 31, 2015"
 
 - name: Rocky Mountain Ruby Conference
   location: Boulder, CO


### PR DESCRIPTION
The conference website (http://www.rubyconf.com.br) is still outdated, but there is another one regarding the dates and the new CFP format.

/cc @akitaonrails