### PR TITLE
Remove finished conferences, fix order of current conferences, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ following items:
 
 ## Contributing
 
-The list of events is driven by the three files in the `data` folder - if you
+The list of events is driven by the two files in the `data` folder - if you
 have an update for those things, just change the JSON and send a PR.
 
-If you have news, please follow the coventions you see in the
+If you have news, please follow the conventions you see in the
 `source/news/posts` folder including filename and title. No biggie if you're not
 sure - this can be tweaked easily enough.
 

--- a/data/current.yml
+++ b/data/current.yml
@@ -1,39 +1,3 @@
-- name: Gotham Ruby Conference
-  location: New York, NY
-  dates: "June 20, 2015"
-  url: http://goruco.com/
-  twitter: goruco
-  reg_phrase: Registration is open
-
-- name: Brighton Ruby
-  location: Brighton, UK
-  dates: "July 20, 2015"
-  url: http://www.brightonruby.com/
-  twitter: brightonruby
-  reg_phrase: Registration is open
-  cfp_phrase: CFP is open
-
-- name: JRubyConf EU
-  location: Potsdam, Germany
-  dates: "July 31, 2015"
-  url: http://jrubyconf.eu
-  twitter: jrubyconfeu
-  reg_phrase: Registration is open
-
-- name: Burlington Ruby Conference
-  location: Burlington, VT
-  dates: "July 31-August 2, 2015"
-  url: http://burlingtonrubyconference.com/
-  twitter: btvrubyconf
-  reg_phrase: Registration is open
-
-- name: eurucamp
-  location: Potsdam, Germany
-  dates: "July 31-August 2, 2015"
-  url: http://eurucamp.org
-  twitter: eurucamp
-  reg_phrase: Registration is open
-
 - name: DeccanRubyConf
   location: Pune, India
   dates: "August 8, 2015"
@@ -123,12 +87,6 @@
   url: http://www.euruko2015.org/
   twitter: euruko
 
-- name: RubyWorld Conference
-  location: Matsue, Japan
-  dates: "November 11-12, 2015"
-  url: http://www.rubyworld-conf.org/
-  twitter: rubyworldconf
-
 - name: Keep Ruby Weird
   location: Austin, Texas
   dates: "October 23, 2015"
@@ -136,6 +94,12 @@
   twitter: keeprubyweird
   cfp_phrase: CFP closes
   cfp_date: "July 31, 2015"
+
+- name: RubyWorld Conference
+  location: Matsue, Japan
+  dates: "November 11-12, 2015"
+  url: http://www.rubyworld-conf.org/
+  twitter: rubyworldconf
 
 - name: RubyDay
   location: Turin, Italy

--- a/data/past.yml
+++ b/data/past.yml
@@ -445,3 +445,33 @@
   dates: "June 12-13, 2015"
   url: http://www.rubynation.org/
   twitter: rubynation
+
+- name: Gotham Ruby Conference
+  location: New York, NY
+  dates: "June 20, 2015"
+  url: http://goruco.com/
+  twitter: goruco
+
+- name: Brighton Ruby
+  location: Brighton, UK
+  dates: "July 20, 2015"
+  url: http://www.brightonruby.com/
+  twitter: brightonruby
+
+- name: JRubyConf EU
+  location: Potsdam, Germany
+  dates: "July 31, 2015"
+  url: http://jrubyconf.eu
+  twitter: jrubyconfeu
+
+- name: Burlington Ruby Conference
+  location: Burlington, VT
+  dates: "July 31-August 2, 2015"
+  url: http://burlingtonrubyconference.com/
+  twitter: btvrubyconf
+
+- name: eurucamp
+  location: Potsdam, Germany
+  dates: "July 31-August 2, 2015"
+  url: http://eurucamp.org
+  twitter: eurucamp


### PR DESCRIPTION
Moved some conferences that have finished to `past.yml`, and fixed the ordering of "RubyWorld Conference". Also fixed some errors in README.md