### PR TITLE
Add Event and News for Ruby devroom at FOSDEM 16

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -52,6 +52,12 @@
   url: http://rubykaigi.org/2015
   twitter: rubykaigi
 
+- name: Ruby devroom at FOSDEM
+  location: Brussels, Belgium
+  dates: "January 31, 2016"
+  url: http://fosdem.rubybelgium.be/
+  twitter: ruby_fosdem
+
 - name: RubyConf Australia
   location: Gold Coast, Australia
   dates: "February 10-13, 2016"

--- a/source/news/posts/2015-11-01-ruby-devroom-fosdem-announces-dates.md
+++ b/source/news/posts/2015-11-01-ruby-devroom-fosdem-announces-dates.md
@@ -1,0 +1,6 @@
+---
+title: Ruby devroom at FOSDEM announces dates.
+---
+
+The dates have been set for Ruby Devroom at FOSDEM: Sunday the 31st January
+2016, mark your calendar.

--- a/source/news/posts/2015-11-01-ruby-devroom-fosdem-opens-cfp.md
+++ b/source/news/posts/2015-11-01-ruby-devroom-fosdem-opens-cfp.md
@@ -1,0 +1,8 @@
+---
+title: Ruby devroom at FOSDEM Opens CFP
+---
+
+The Ruby devroom at FOSDEM [call for proprosals][cfp] is open now through
+December 1st 2015.
+
+[cfp]: http://fosdem.rubybelgium.be/cfp.html

--- a/source/news/posts/2015-11-23-ruby-devroom-fosdem-cfp-closes-soon.md
+++ b/source/news/posts/2015-11-23-ruby-devroom-fosdem-cfp-closes-soon.md
@@ -1,0 +1,7 @@
+---
+title: Ruby devroom at FOSDEM CFP Closes Soon
+---
+
+The Ruby devroom at FOSDEM [call for proprosals][cfp] closes December 1st.
+
+[cfp]: http://fosdem.rubybelgium.be/cfp.html

--- a/source/news/posts/2015-11-30-ruby-devroom-fosdem-cfp-closes-tomorrow.md
+++ b/source/news/posts/2015-11-30-ruby-devroom-fosdem-cfp-closes-tomorrow.md
@@ -1,0 +1,8 @@
+---
+title: Ruby devroom at FOSDEM CFP Closes Tomorrow
+---
+
+The Ruby devroom at FOSDEM [call for proprosals][cfp] closes tomorrow, December
+1st.
+
+[cfp]: http://fosdem.rubybelgium.be/cfp.html


### PR DESCRIPTION
Hi,

I'd like to announce the [Ruby devroom at FOSDEM 2016](http://fosdem.rubybelgium.be).

As reminder, it's dedicated to internals and implementations of Rubies. Last year, we managed to [gather contributors](https://archive.fosdem.org/2015/schedule/track/ruby/) of the JVM, MRI, RubyMotion, or Truffle.

Thanks!