### PR TITLE
Update past events, video links, add RubyConf 2016

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -1,9 +1,3 @@
-- name: RubyWorld Conference
-  location: Matsue, Japan
-  dates: "November 11-12, 2015"
-  url: http://www.rubyworld-conf.org/
-  twitter: rubyworldconf
-
 - name: RubyDay
   location: Turin, Italy
   dates: "November 13, 2015"

--- a/data/current.yml
+++ b/data/current.yml
@@ -4,8 +4,6 @@
   url: http://railsisrael2015.events.co.il
   twitter: fogelmania
   reg_phrase: Registration is open
-  cfp_phrase: CFP closes
-  cfp_date: "November 5, 2015"
 
 - name: RubyKaigi
   location: Tokyo, Japan

--- a/data/current.yml
+++ b/data/current.yml
@@ -1,10 +1,3 @@
-- name: RubyDay
-  location: Turin, Italy
-  dates: "November 13, 2015"
-  url: http://www.rubyday.it
-  twitter: rubydayit
-  reg_phrase: Registration is open
-
 - name: RubyConf
   location: San Antonio, TX
   dates: "November 15-17, 2015"

--- a/data/current.yml
+++ b/data/current.yml
@@ -49,3 +49,9 @@
   dates: "July 8, 2016"
   url: http://brightonruby.com
   twitter: brightonruby
+
+- name: RubyConf
+  location: Cincinnati, OH
+  dates: "November 10-12, 2016"
+  url: http://rubyconf.org/
+  twitter: rubyconf

--- a/data/current.yml
+++ b/data/current.yml
@@ -1,10 +1,3 @@
-- name: RubyConf
-  location: San Antonio, TX
-  dates: "November 15-17, 2015"
-  url: http://rubyconf.org/
-  twitter: rubyconf
-  reg_phrase: Registration is open
-
 - name: RailsIsrael
   location: Tel Aviv, Israel
   dates: "November 24, 2015"

--- a/data/past.yml
+++ b/data/past.yml
@@ -561,3 +561,10 @@
   dates: "October 23, 2015"
   url: http://keeprubyweird.com
   twitter: keeprubyweird
+
+- name: RubyWorld Conference
+  location: Matsue, Japan
+  dates: "November 11-12, 2015"
+  url: http://www.rubyworld-conf.org/
+  twitter: rubyworldconf
+

--- a/data/past.yml
+++ b/data/past.yml
@@ -560,6 +560,7 @@
   dates: "October 23, 2015"
   url: http://keeprubyweird.com
   twitter: keeprubyweird
+  video_link: http://confreaks.tv/events/keeprubyweird2015
 
 - name: RubyWorld Conference
   location: Matsue, Japan
@@ -578,3 +579,4 @@
   dates: "November 15-17, 2015"
   url: http://rubyconf.org/
   twitter: rubyconf
+  video_link: http://confreaks.tv/events/rubyconf2015

--- a/data/past.yml
+++ b/data/past.yml
@@ -573,3 +573,9 @@
   dates: "November 13, 2015"
   url: http://www.rubyday.it
   twitter: rubydayit
+
+- name: RubyConf
+  location: San Antonio, TX
+  dates: "November 15-17, 2015"
+  url: http://rubyconf.org/
+  twitter: rubyconf

--- a/data/past.yml
+++ b/data/past.yml
@@ -548,7 +548,6 @@
   dates: "October 15-16, 2015"
   url: http://www.rubyconf.co/
   twitter: rubyconfco
-  reg_phrase: Registration is open
 
 - name: EuRuKo
   location: Salzburg, Austria

--- a/data/past.yml
+++ b/data/past.yml
@@ -530,6 +530,7 @@
   dates: "September 23-25, 2015"
   url: http://www.rockymtnruby.com/
   twitter: rockymtnruby
+  video_link: http://www.confreaks.com/events/rmr2014
 
 - name: ROSSConf Berlin
   location: Berlin, Germany

--- a/data/past.yml
+++ b/data/past.yml
@@ -543,6 +543,13 @@
   url: http://2015.arrrrcamp.be
   twitter: arrrrcamp
 
+- name: Los Angeles Ruby Conference
+  location: Los Angeles, CA
+  dates: "October 10, 2015"
+  url: http://larubyconf.com/
+  twitter: larubyconf
+  video_link: http://confreaks.com/events/larubyconf2015
+
 - name: RubyConf Colombia
   location: Medellin, Colombia
   dates: "October 15-16, 2015"

--- a/data/past.yml
+++ b/data/past.yml
@@ -568,3 +568,8 @@
   url: http://www.rubyworld-conf.org/
   twitter: rubyworldconf
 
+- name: RubyDay
+  location: Turin, Italy
+  dates: "November 13, 2015"
+  url: http://www.rubyday.it
+  twitter: rubydayit


### PR DESCRIPTION
Just made a few updates individual commits.

Added a few historical conferences with video links while I was adding some other recent videos (eg LARubyConf 2015).

Thanks as always for this service!