### PR TITLE
Uses railsconf.com instead of .org

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -49,7 +49,7 @@
 - name: RailsConf
   location: Kansas City, MO
   dates: "May 4-6, 2016"
-  url: http://railsconf.org/
+  url: http://railsconf.com/
   twitter: rubyconf
   cfp_phrase: CFP is open
 


### PR DESCRIPTION
The .org redirects to railsconf2012.com which gives an error