### PR TITLE
Add RubyKaigi 2016 🇯🇵

### DIFF
--- a/data/current.yml
+++ b/data/current.yml
@@ -85,6 +85,12 @@
   url: http://brightonruby.com
   twitter: brightonruby
 
+- name: RubyKaigi
+  location: Kyoto, Japan
+  dates: "September 8-10, 2016"
+  url: http://rubykaigi.org/2016
+  twitter: rubykaigi
+
 - name: WindyCityRails
   location: Chicago, IL
   dates: "September 15-16, 2016"


### PR DESCRIPTION
RubyKaigi, the annual international Ruby conference in Japan, will be held in September.
And the venue is not in Tokyo this year. It's happening in the thousand-year ancient capital of Japan!